### PR TITLE
Add extern "C" to gifski.h so it can be used in C++ without modification

### DIFF
--- a/gifski.h
+++ b/gifski.h
@@ -2,6 +2,11 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct gifski;
 typedef struct gifski gifski;
 
@@ -193,3 +198,7 @@ GifskiError gifski_write(gifski *handle, const char *destination);
  * Call to free all memory
  */
 void gifski_drop(gifski *g);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
The `gifski.h` header does not wrap the API definition in `extern "C"` which leads to linker issues due to mangling in C++. Fixed in this PR.