### PR TITLE
snap: Add snapcraft.yaml file

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,24 @@
+name: gifski
+version: 0.8.5
+summary: gifski
+description: |
+   GIF encoder based on libimagequant (pngquant).
+   Squeezes maximum possible quality from the awful
+   GIF format. https://gif.ski
+
+confinement: strict
+
+apps:
+  gifski:
+    command: gifski
+    plugs:
+    - home
+
+parts:
+  gifski:
+    source-type: git
+    source: https://github.com/ImageOptim/gifski.git
+    source-tag: 0.8.5
+    plugin: rust
+    rust-features:
+      - openmp


### PR DESCRIPTION
This commit introduces support for bundling/delivering gifski through
the 'snap' mechanism/store - more details at http://snapcraft.io.

"A snap is a bundle of your app and its dependencies that works without
modification across Linux. Snaps are discoverable and installable from
the Snap store, an app store with an audience of millions." [1]

In case the support/snapcraft.yaml file is accepted it can be published
in the Snap Store [2] which is required for people to easily install it.

Assistance for publishing in the snap store is available if required.

Test Procedure
==============

*Build/Snap
-----------

$ lxc launch ubuntu:16.04 snapcrafting  # create 'snapcrafting' container
$ lxc exec snapcrafting -- su - ubuntu  # execute user shell in container

$ sudo snap install snapcraft --classic # install snapcraft tool/commands

$ [get this snapcraft.yaml file]
$ snapcraft

...
 [Relatively large build output]
Snapped gifski_0.8.5_amd64.snap
...

*Install/Contents
-----------------

$ sudo snap install gifski_0.8.5_amd64.snap --dangerous # '--dangerous' is required as this isn't from the store.

$ which gifski
/snap/bin/gifski

*Testing
--------

$ wget -q http://techslides.com/demos/sample-videos/small.webm
$ ffmpeg -i small.webm frame%04d.png

$ gifski -o anim.gif frame*.png
$ ls -lh anim.gif
<...> 11M Dec  5 13:57 anim.gif

References:
[1] "Creating a snap" in https://docs.snapcraft.io/creating-a-snap
[2] "Share with your friends" in https://docs.snapcraft.io/rust-applications

Signed-off-by: Guilherme G. Piccoli <gpiccoli@canonical.com>
[This commit message was highly based in the great template from
Mauricio Faria de Oliveira at https://github.com/kornelski/pngquant/commit/a8e7d1e]