### PR TITLE
Fix snap building by migrating the snap to core18 base

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -6,6 +6,7 @@ description: |
    Squeezes maximum possible quality from the awful
    GIF format. https://gif.ski
 
+base: core18
 confinement: strict
 
 apps:
@@ -22,3 +23,5 @@ parts:
     plugin: rust
     rust-features:
       - openmp
+    stage-packages:
+      - libgomp1


### PR DESCRIPTION
This patch ports the recipe to core18 base so that it will benefit from
the rust plugin fix.

Additional stage package is enumerated according to Snapcraft's hint.

Note that the snap is now core18 base and requires an Ubuntu 18.04
equivalent system in order to build(the officially supported multipass
build environment should handle this automatically[1]).

Fixes canonical-websites/build.snapcraft.io#1203.

[1] https://docs.snapcraft.io/snapcraft-overview/8940

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>