### PR TITLE
snap: Incorporate selective-checkout to build latest release when available

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,11 +1,11 @@
 name: gifski
-version: 0.8.5
 summary: gifski
 description: |
    GIF encoder based on libimagequant (pngquant).
    Squeezes maximum possible quality from the awful
    GIF format. https://gif.ski
 
+adopt-info: gifski
 base: core18
 confinement: strict
 
@@ -17,11 +17,26 @@ apps:
 
 parts:
   gifski:
-    source-type: git
+    after:
+      - selective-checkout
+
     source: https://github.com/ImageOptim/gifski.git
-    source-tag: 0.8.5
+    override-pull: |
+      snapcraftctl pull
+
+      "$SNAPCRAFT_STAGE"/scriptlets/selective-checkout
+
     plugin: rust
     rust-features:
       - openmp
     stage-packages:
       - libgomp1
+
+  selective-checkout:
+    plugin: nil
+    build-packages:
+    - git
+    stage-snaps:
+    - selective-checkout
+    prime:
+    - -*


### PR DESCRIPTION
This patch enables building 0.8.7, and the future development snapshot
builds after it being promoted to the stable channel.

Refer-to: Selective-checkout: Check out the tagged release revision if
it isn't promoted to the stable channel - doc - snapcraft.io
<https://forum.snapcraft.io/t/selective-checkout-check-out-the-tagged-release-revision-if-it-isnt-promoted-to-the-stable-channel/10617>
Refer-to: Using external metadata - doc - snapcraft.io
<https://forum.snapcraft.io/t/using-external-metadata/4642>
Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>