### PR TITLE
snap: Connect to removable-media interface to allow access to /media

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -14,6 +14,7 @@ apps:
     command: gifski
     plugs:
     - home
+    - removable-media
 
 parts:
   gifski:


### PR DESCRIPTION
Refer-to: The removable-media interface - doc - snapcraft.io
<https://forum.snapcraft.io/t/the-removable-media-interface/7910>
Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>