### PR TITLE
Remove invalid brew install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ See [releases](https://github.com/ImageOptim/gifski/releases) page for executabl
 
 If you have [Rust](https://www.rust-lang.org/install.html) 1.31+, you can also get it with [`cargo install gifski`](https://crates.rs/crates/gifski). Run `cargo build --release --features=openmp` to build from source.
 
-If you have [Homebrew](https://brew.sh/), you can also get it with `brew install gifski`. Add the `--with-openmp` to make it run faster.
+If you have [Homebrew](https://brew.sh/), you can also get it with `brew install gifski`.
 
 ## Usage
 


### PR DESCRIPTION
All formulae in homebrew-core had their options removed (https://github.com/Homebrew/homebrew-core/issues/31510). Using `--with-openmp` throws an error now.