### PR TITLE
Use libavfilter for FPS manipulation for video sources, add speed option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ dependencies = [
 [[package]]
 name = "ffmpeg"
 version = "0.2.0"
-source = "git+https://github.com/kornelski/rust-ffmpeg.git?rev=e8fa3a3e4718c32f2bb89f33a2dfc2dedd4f1e6d#e8fa3a3e4718c32f2bb89f33a2dfc2dedd4f1e6d"
+source = "git+https://github.com/kornelski/rust-ffmpeg.git?rev=83ee1c4f5a6f09ce03671861f431e1f015095952#83ee1c4f5a6f09ce03671861f431e1f015095952"
 dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffmpeg-sys 4.2.1 (git+https://github.com/kornelski/rust-ffmpeg-sys)",
@@ -203,7 +203,7 @@ name = "gifski"
 version = "1.0.1"
 dependencies = [
  "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffmpeg 0.2.0 (git+https://github.com/kornelski/rust-ffmpeg.git?rev=e8fa3a3e4718c32f2bb89f33a2dfc2dedd4f1e6d)",
+ "ffmpeg 0.2.0 (git+https://github.com/kornelski/rust-ffmpeg.git?rev=83ee1c4f5a6f09ce03671861f431e1f015095952)",
  "gif 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gif-dispose 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gifsicle 1.92.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -550,7 +550,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum crossbeam-channel 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061"
 "checksum crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 "checksum env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
-"checksum ffmpeg 0.2.0 (git+https://github.com/kornelski/rust-ffmpeg.git?rev=e8fa3a3e4718c32f2bb89f33a2dfc2dedd4f1e6d)" = "<none>"
+"checksum ffmpeg 0.2.0 (git+https://github.com/kornelski/rust-ffmpeg.git?rev=83ee1c4f5a6f09ce03671861f431e1f015095952)" = "<none>"
 "checksum ffmpeg-sys 4.2.1 (git+https://github.com/kornelski/rust-ffmpeg-sys)" = "<none>"
 "checksum gif 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)" = "471d90201b3b223f3451cd4ad53e34295f16a1df17b1edf3736d47761c3981af"
 "checksum gif-dispose 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fd26e2d78d52daca286297ba6ddf46ac24924ba1135ab37aaa6ea9a9c0967aa9"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,13 +33,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bindgen"
-version = "0.52.0"
+version = "0.54.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cexpr 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cexpr 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "clang-sys 0.28.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clang-sys 0.29.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -53,11 +53,6 @@ dependencies = [
  "shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "which 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "bitflags"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
@@ -76,10 +71,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cexpr"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 5.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -89,7 +84,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "clang-sys"
-version = "0.28.1"
+version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -148,26 +143,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "ffmpeg"
-version = "0.2.0"
-source = "git+https://github.com/kornelski/rust-ffmpeg.git?rev=83ee1c4f5a6f09ce03671861f431e1f015095952#83ee1c4f5a6f09ce03671861f431e1f015095952"
+name = "ffmpeg-next"
+version = "4.3.4"
+source = "git+https://github.com/zmwangx/rust-ffmpeg.git?rev=f1ccd4e69641dbd2be98e3ef38e670b592a103c1#f1ccd4e69641dbd2be98e3ef38e670b592a103c1"
 dependencies = [
- "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffmpeg-sys 4.2.1 (git+https://github.com/kornelski/rust-ffmpeg-sys)",
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffmpeg-sys-next 4.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "ffmpeg-sys"
-version = "4.2.1"
-source = "git+https://github.com/kornelski/rust-ffmpeg-sys#e8a28ab79a71c43d5a04dd8439c71a29c357dba7"
+name = "ffmpeg-sys-next"
+version = "4.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bindgen 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bindgen 0.54.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -203,7 +198,7 @@ name = "gifski"
 version = "1.0.1"
 dependencies = [
  "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffmpeg 0.2.0 (git+https://github.com/kornelski/rust-ffmpeg.git?rev=83ee1c4f5a6f09ce03671861f431e1f015095952)",
+ "ffmpeg-next 4.3.4 (git+https://github.com/zmwangx/rust-ffmpeg.git?rev=f1ccd4e69641dbd2be98e3ef38e670b592a103c1)",
  "gif 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gif-dispose 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gifsicle 1.92.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -326,11 +321,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "nom"
-version = "4.2.3"
+version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -480,13 +475,18 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "version_check"
-version = "0.1.5"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -537,21 +537,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
-"checksum bindgen 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f1c85344eb535a31b62f0af37be84441ba9e7f0f4111eb0530f43d15e513fe57"
-"checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
+"checksum bindgen 0.54.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f4d49b80beb70d76cdac92f5681e666f9a697c737c4f4117a67229a0386dc736"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum bytemuck 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37fa13df2292ecb479ec23aa06f4507928bef07839be9ef15281411076629431"
 "checksum cc 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)" = "0fde55d2a2bfaa4c9668bbc63f531fbdeee3ffe188f4662511ce2c22b3eedebe"
-"checksum cexpr 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fce5b5fb86b0c57c20c834c1b412fd09c77c8a59b9473f86272709e78874cd1d"
+"checksum cexpr 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-"checksum clang-sys 0.28.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81de550971c976f176130da4b2978d3b524eaa0fd9ac31f3ceb5ae1231fb4853"
+"checksum clang-sys 0.29.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fe6837df1d5cba2397b835c8530f51723267e16abbf83892e9e5af4f0e5dd10a"
 "checksum clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
 "checksum color_quant 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0dbbb57365263e881e805dc77d94697c9118fd94d8da011240555aa7b23445bd"
 "checksum crossbeam-channel 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061"
 "checksum crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 "checksum env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
-"checksum ffmpeg 0.2.0 (git+https://github.com/kornelski/rust-ffmpeg.git?rev=83ee1c4f5a6f09ce03671861f431e1f015095952)" = "<none>"
-"checksum ffmpeg-sys 4.2.1 (git+https://github.com/kornelski/rust-ffmpeg-sys)" = "<none>"
+"checksum ffmpeg-next 4.3.4 (git+https://github.com/zmwangx/rust-ffmpeg.git?rev=f1ccd4e69641dbd2be98e3ef38e670b592a103c1)" = "<none>"
+"checksum ffmpeg-sys-next 4.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a0f343de3e46fbf5fb95a1a35600eab07adc7f41456c5018bca248c90b0f8345"
 "checksum gif 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)" = "471d90201b3b223f3451cd4ad53e34295f16a1df17b1edf3736d47761c3981af"
 "checksum gif-dispose 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fd26e2d78d52daca286297ba6ddf46ac24924ba1135ab37aaa6ea9a9c0967aa9"
 "checksum gifsicle 1.92.0 (registry+https://github.com/rust-lang/crates.io-index)" = "430b8c1b679b0814dfe7e2912e4f3766f00f5e95d1b3570d3a1c6e08c2395ec4"
@@ -571,7 +570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 "checksum natord 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c"
-"checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
+"checksum nom 5.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 "checksum num_cpus 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 "checksum openmp-sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6d6ba0f6d9bcda83ebd8c1648715fb91f6ecd9303f240d55c2041c48222a9a13"
 "checksum pbr 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "74333e3d1d8bced07fd0b8599304825684bcdb4a1fcc6fa6a470e6e08cefd254"
@@ -593,8 +592,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum time 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 "checksum unicode-width 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 "checksum unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+"checksum vcpkg 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
 "checksum vec_map 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 "checksum which 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
 "checksum wild 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "035793abb854745033f01a07647a79831eba29ec0be377205f2a25b0aa830020"
 "checksum winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,11 @@ natord = "1.0.9"
 quick-error = "1.2.3"
 
 [dependencies.ffmpeg]
-rev = "e8fa3a3e4718c32f2bb89f33a2dfc2dedd4f1e6d"
+rev = "83ee1c4f5a6f09ce03671861f431e1f015095952"
 optional = true
 git = "https://github.com/kornelski/rust-ffmpeg.git"
-features = ["codec", "format", "filter", "software-resampling", "software-scaling", "resampling" ]
+default-features = false
+features = ["ffmpeg4", "codec", "format", "filter", "software-resampling", "software-scaling"]
 
 [features]
 default = []
@@ -56,6 +57,3 @@ opt-level = 3
 [profile.release]
 panic = "abort"
 lto = true
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,18 +33,16 @@ wild = "2.0.4"
 natord = "1.0.9"
 quick-error = "1.2.3"
 
-[dependencies.ffmpeg]
-rev = "83ee1c4f5a6f09ce03671861f431e1f015095952"
+[dependencies.ffmpeg-next]
+rev = "f1ccd4e69641dbd2be98e3ef38e670b592a103c1"
 optional = true
-git = "https://github.com/kornelski/rust-ffmpeg.git"
-default-features = false
-features = ["ffmpeg4", "codec", "format", "filter", "software-resampling", "software-scaling"]
+git = "https://github.com/zmwangx/rust-ffmpeg.git"
 
 [features]
 default = []
 openmp = ["imagequant/openmp"]
 openmp-static = ["imagequant/openmp-static"]
-video = ["ffmpeg"]
+video = ["ffmpeg-next"]
 malloc = []
 
 [lib]
@@ -57,3 +55,6 @@ opt-level = 3
 [profile.release]
 panic = "abort"
 lto = true
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/src/bin/ffmpeg_source.rs
+++ b/src/bin/ffmpeg_source.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 pub struct FfmpegDecoder {
     input_context: ffmpeg::format::context::Input,
     frames: u64,
+    speed: f32,
     pts_frame_step: f64,
     min_pts: f64,
 }
@@ -22,15 +23,23 @@ impl Source for FfmpegDecoder {
 }
 
 impl FfmpegDecoder {
-    pub fn new(path: &Path, fps: f32) -> BinResult<Self> {
+    pub fn new(path: &Path, fps: f32, speed: f32) -> BinResult<Self> {
         ffmpeg::init().map_err(|e| format!("Unable to initialize ffmpeg: {}", e))?;
         let input_context = ffmpeg::format::input(&path)
             .map_err(|e| format!("Unable to open video file {}: {}", path.display(), e))?;
         // take fps override into account
-        let frames = input_context.streams().best(ffmpeg::media::Type::Video).ok_or("The file has no video tracks")?.frames() as u64;
+        let stream = input_context.streams().best(ffmpeg::media::Type::Video).ok_or("The file has no video tracks")?;
+        let rate = stream.avg_frame_rate().numerator() as f64 / stream.avg_frame_rate().denominator() as f64;
+        let max_fps = rate as f32 * speed;
+        if fps > max_fps {
+            eprintln!("Target frame rate is at most {:.2}fps based on the average frame rate of input source.\n\
+                       The specified target will net be reached. It will still be used to filter out higher-speed portions in the input.", max_fps=max_fps);
+        }
+        let frames = stream.frames() as u64;
         Ok(Self {
             input_context,
-            frames,
+            frames: (frames as f64 / rate * match fps > max_fps { true => max_fps, false => fps } as f64 / speed as f64) as u64,
+            speed,
             pts_frame_step: 1.0 / fps as f64,
             min_pts: 0.0,
         })
@@ -47,7 +56,6 @@ impl FfmpegDecoder {
         };
 
         let mut i = 0;
-        let mut prev_pts = 0;
         for (s, packet) in self.input_context.packets() {
             if s.index() != stream_index {
                 continue;
@@ -69,9 +77,10 @@ impl FfmpegDecoder {
                 stride,
             );
 
-            let pts = vid_frame.pts().unwrap_or(prev_pts + 1);
-            prev_pts = pts;
-            let ptsf = (pts as u64 * time_base.numerator() as u64) as f64 / f64::from(time_base.denominator());
+            let timestamp = vid_frame.timestamp();
+            vid_frame.set_pts(timestamp);
+            let pts = vid_frame.pts().unwrap();
+            let ptsf = (pts as u64 * time_base.numerator() as u64) as f64 / f64::from(time_base.denominator()) / self.speed as f64;
 
             if ptsf >= self.min_pts {
                 dest.add_frame_rgba(i, rgba_frame, ptsf)?;

--- a/src/bin/ffmpeg_source.rs
+++ b/src/bin/ffmpeg_source.rs
@@ -1,3 +1,4 @@
+extern crate ffmpeg_next as ffmpeg;
 use crate::BinResult;
 use gifski::Collector;
 use imgref::*;
@@ -8,9 +9,9 @@ use std::path::Path;
 pub struct FfmpegDecoder {
     input_context: ffmpeg::format::context::Input,
     frames: u64,
+    fps: f32,
     speed: f32,
-    pts_frame_step: f64,
-    min_pts: f64,
+    time_base: f64,
 }
 
 impl Source for FfmpegDecoder {
@@ -29,46 +30,47 @@ impl FfmpegDecoder {
             .map_err(|e| format!("Unable to open video file {}: {}", path.display(), e))?;
         // take fps override into account
         let stream = input_context.streams().best(ffmpeg::media::Type::Video).ok_or("The file has no video tracks")?;
-        let rate = stream.avg_frame_rate().numerator() as f64 / stream.avg_frame_rate().denominator() as f64;
-        let max_fps = rate as f32 * speed;
-        if fps > max_fps {
-            eprintln!("Target frame rate is at most {:.2}fps based on the average frame rate of input source.\n\
-                       The specified target will net be reached. It will still be used to filter out higher-speed portions in the input.", max_fps=max_fps);
-        }
-        let frames = stream.frames() as u64;
+        let time_base = stream.time_base().numerator() as f64 / stream.time_base().denominator() as f64;
+        let frames = (stream.duration() as f64 * time_base as f64 * (fps / speed) as f64).ceil() as u64;
         Ok(Self {
             input_context,
-            frames: (frames as f64 / rate * match fps > max_fps { true => max_fps, false => fps } as f64 / speed as f64) as u64,
+            frames,
+            fps,
             speed,
-            pts_frame_step: 1.0 / fps as f64,
-            min_pts: 0.0,
+            time_base,
         })
     }
 
     pub fn collect_frames(&mut self, mut dest: Collector) -> BinResult<()> {
-        let (stream_index, mut decoder, mut converter, time_base) = {
+        let (stream_index, mut decoder, mut filter, time_base) = {
             let stream = self.input_context.streams().best(ffmpeg::media::Type::Video).ok_or("The file has no video tracks")?;
 
             let decoder = stream.codec().decoder().video().map_err(|e| format!("Unable to decode the codec used in the video: {}", e))?;
 
-            let converter = decoder.converter(ffmpeg::util::format::pixel::Pixel::RGBA)?;
-            (stream.index(), decoder, converter, stream.time_base())
+            let time_base = self.time_base / self.speed as f64;
+            let buffer_args = format!("width={}:height={}:pix_fmt={}:time_base={}:sar={}",
+                decoder.width(),
+                decoder.height(),
+                decoder.format().descriptor().unwrap().name(),
+                stream.time_base(),
+                (|sar: ffmpeg::util::rational::Rational| match sar.numerator() {
+                    0 => "1".to_string(),
+                    _ => format!("{}/{}", sar.numerator(), sar.denominator()),
+                })(decoder.aspect_ratio()),
+            );
+            let mut filter = ffmpeg::filter::Graph::new();
+            filter.add(&ffmpeg::filter::find("buffer").unwrap(), "in", &buffer_args)?;
+            filter.add(&ffmpeg::filter::find("buffersink").unwrap(), "out", "")?;
+            filter.output("in", 0)?.input("out", 0)?.parse(&format!("fps=fps={}:eof_action=pass,format=rgba", self.fps / self.speed)[..])?;
+            filter.validate()?;
+            (stream.index(), decoder, filter, time_base)
         };
 
         let mut i = 0;
-        for (s, packet) in self.input_context.packets() {
-            if s.index() != stream_index {
-                continue;
-            }
-            let mut vid_frame = ffmpeg::util::frame::video::Video::empty();
-            let decoded = decoder.decode(&packet, &mut vid_frame)?;
-            if !decoded || 0 == vid_frame.width() {
-                continue;
-            }
-
-            let mut rgba_frame = ffmpeg::util::frame::video::Video::empty();
-            converter.run(&vid_frame, &mut rgba_frame)?;
-
+        let mut ptsf = 0;
+        let mut vid_frame = ffmpeg::util::frame::Video::empty();
+        let mut filt_frame = ffmpeg::util::frame::Video::empty();
+        let mut add_frame = |rgba_frame: &ffmpeg::util::frame::Video, pts: f64, pos: i64| -> BinResult<()> {
             let stride = rgba_frame.stride(0) as usize / 4;
             let rgba_frame = ImgVec::new_stride(
                 rgba_frame.data(0).as_rgba().to_owned(),
@@ -76,17 +78,32 @@ impl FfmpegDecoder {
                 rgba_frame.height() as usize,
                 stride,
             );
+            Ok(dest.add_frame_rgba(pos as usize, rgba_frame, pts)?)
+        };
 
-            let timestamp = vid_frame.timestamp();
-            vid_frame.set_pts(timestamp);
-            let pts = vid_frame.pts().unwrap();
-            let ptsf = (pts as u64 * time_base.numerator() as u64) as f64 / f64::from(time_base.denominator()) / self.speed as f64;
-
-            if ptsf >= self.min_pts {
-                dest.add_frame_rgba(i, rgba_frame, ptsf)?;
-                i += 1;
-                self.min_pts += self.pts_frame_step;
+        for (s, packet) in self.input_context.packets() {
+            if s.index() != stream_index {
+                continue;
             }
+            let decoded = decoder.decode(&packet, &mut vid_frame)?;
+            if !decoded || 0 == vid_frame.width() {
+                continue;
+            }
+
+            filter.get("in").unwrap().source().add(&vid_frame).unwrap();
+            while let Ok(..) = filter.get("out").unwrap().sink().frame(&mut filt_frame) { 
+                ptsf = filt_frame.timestamp().unwrap();
+                add_frame(&filt_frame, ptsf as f64 * time_base, i)?;
+                i += 1;
+            }
+        }
+        // round EOF to least integral upper bound
+        let pts_final = ptsf + (1.5 / time_base / self.fps as f64) as i64;
+        filter.get("in").unwrap().source().close(pts_final).unwrap();
+        while let Ok(..) = filter.get("out").unwrap().sink().frame(&mut filt_frame) { 
+            ptsf = filt_frame.timestamp().unwrap();
+            add_frame(&filt_frame, ptsf as f64 * time_base, i)?;
+            i += 1;
         }
         Ok(())
     }

--- a/src/bin/gifski.rs
+++ b/src/bin/gifski.rs
@@ -8,7 +8,7 @@ static A: System = System;
 #[macro_use] extern crate clap;
 
 #[cfg(feature = "video")]
-extern crate ffmpeg;
+extern crate ffmpeg_next as ffmpeg;
 
 use natord;
 use wild;

--- a/src/bin/gifski.rs
+++ b/src/bin/gifski.rs
@@ -63,13 +63,24 @@ fn bin_main() -> BinResult<()> {
                             .required(true))
                         .arg(Arg::with_name("fps")
                             .long("fps")
-                            .help("Animation frames per second (for PNG frames only)")
+                            .short("r")
+                            .help("Animation frames per second (for PNG frames) or \n\
+                                   downcapped video frame rate (for video sources), \n\
+                                   in which case the value is at most the source \n\
+                                   frame rate times the speed")
                             .empty_values(false)
                             .value_name("num")
                             .default_value("20"))
+                        .arg(Arg::with_name("speed")
+                            .long("speed")
+                            .short("S")
+                            .help("Adjust speed of animation by a factor (no effect \nfor PNG frames)")
+                            .empty_values(false)
+                            .value_name("num")
+                            .default_value("1"))
                         .arg(Arg::with_name("fast")
                             .long("fast")
-                            .help("3 times faster encoding, but 10% lower quality and bigger file"))
+                            .help("3 times faster encoding, but 10% lower quality and \nbigger file"))
                         .arg(Arg::with_name("quality")
                             .long("quality")
                             .value_name("1-100")
@@ -92,7 +103,7 @@ fn bin_main() -> BinResult<()> {
                             .help("Do not loop the GIF"))
                         .arg(Arg::with_name("nosort")
                             .long("nosort")
-                            .help("Use files exactly in the order given, rather than sorted"))
+                            .help("Use files exactly in the order given, rather than \nsorted"))
                         .arg(Arg::with_name("quiet")
                             .long("quiet")
                             .help("Do not show a progress bar"))
@@ -120,6 +131,7 @@ fn bin_main() -> BinResult<()> {
     };
     let quiet = matches.is_present("quiet");
     let fps: f32 = matches.value_of("fps").ok_or("Missing fps")?.parse().map_err(|_| "FPS must be a number")?;
+    let speed: f32 = matches.value_of("speed").ok_or("Missing speed")?.parse().map_err(|_| "Speed must be a number")?;
 
     if settings.quality < 20 {
         if settings.quality < 1 {
@@ -134,7 +146,7 @@ fn bin_main() -> BinResult<()> {
     check_if_path_exists(&frames[0])?;
 
     let mut decoder = if frames.len() == 1 {
-        get_video_decoder(&frames[0], fps)?
+        get_video_decoder(&frames[0], fps, speed)?
     } else {
         Box::new(png::Lodecoder::new(frames, fps))
     };
@@ -187,12 +199,12 @@ fn parse_opt<T: ::std::str::FromStr<Err = ::std::num::ParseIntError>>(s: Option<
 }
 
 #[cfg(feature = "video")]
-fn get_video_decoder(path: &Path, fps: f32) -> BinResult<Box<dyn Source + Send>> {
-    Ok(Box::new(ffmpeg_source::FfmpegDecoder::new(path, fps)?))
+fn get_video_decoder(path: &Path, fps: f32, speed: f32) -> BinResult<Box<dyn Source + Send>> {
+    Ok(Box::new(ffmpeg_source::FfmpegDecoder::new(path, fps, speed)?))
 }
 
 #[cfg(not(feature = "video"))]
-fn get_video_decoder(_: &Path, _fps: f32) -> BinResult<Box<dyn Source + Send>> {
+fn get_video_decoder(_: &Path, _: f32, _: f32) -> BinResult<Box<dyn Source + Send>> {
     Err(r"Video support is permanently disabled in this executable.
 
 To enable video decoding you need to recompile gifski from source with:


### PR DESCRIPTION
This PR makes use of libavfilter to control frame rate (via the `fps` filter) as well as to handle pixel format conversion (for convenience's sake).

The advantage of this approach is to have the ability to duplicate frames when needed to achieve constant frame rate (may be unfavorable in some cases, so there could be an option to turn this off.

In theory the user could pass a complex filtergraph (but with one input and one output, obviously) and do all kinds of stuff here, but that isn't what this tool is for.

So instead of full customization, an option is added to allow adjusting the playback speed (and effectively, frame rate, but not the number of frames, similar to changing the frame rate for PNG input sources). There's an implementation without enabling the FPS filter at branch `master`, with minor fixes (estimated number of frames, which is at least by best effort now, instead of just using the source value even when frames are dropped).

P. S.: initially this PR was to fix the build issue, so that is also included (in `master`, it's now irrelevant here due to switching to `ffmpeg-next`). The reason was the deprecation of `libavresample` from most packaged distributions of FFmpeg.

P. P. S.: I'm actually using this with Node.js on my server and find it great to have the `--quiet` option. It'll really be better to have pipe support though (granted, I could use named pipes, but I am yet to find a good cross-platform solution). I currently just use temporary files for this.

P. P. P. S.: `ffmpeg-next` has exposed `util::log` today. I find it extremely useful for debugging. I really hope you can migrate to that for the future as it seems to work well and the development is active (the bug I encountered here was solved in a day).