### PR TITLE
Adds the ability to set the number of loops for an animation

### DIFF
--- a/gifski.h
+++ b/gifski.h
@@ -54,7 +54,7 @@ typedef struct GifskiSettings {
    */
   bool fast;
   /**
-   * 0+, but useful range is 1-10. Recommended to set to 5. If loop_count is > 0 once should be set to true
+   * 0+, but useful range is 0-10. 0 is loop forever. Recommended to set to 0.
    */
   uint16_t loop_count;
 } GifskiSettings;

--- a/gifski.h
+++ b/gifski.h
@@ -53,6 +53,10 @@ typedef struct GifskiSettings {
    * Lower quality, but faster encode.
    */
   bool fast;
+  /**
+   * 0+, but useful range is 1-10. Recommended to set to 5. If loop_count is > 0 once should be set to true
+   */
+  uint16_t loop_count;
 } GifskiSettings;
 
 enum GifskiError {

--- a/src/bin/gifski.rs
+++ b/src/bin/gifski.rs
@@ -156,10 +156,6 @@ fn bin_main() -> BinResult<()> {
         eprintln!("warning: web browsers support max 50 fps");
     }
 
-    if settings.loop_count > 0 {
-        settings.once = true;
-    }
-
     check_if_paths_exist(&frames)?;
 
     let mut decoder = if frames.len() == 1 {

--- a/src/bin/gifski.rs
+++ b/src/bin/gifski.rs
@@ -106,6 +106,11 @@ fn bin_main() -> BinResult<()> {
                             .empty_values(false)
                             .use_delimiter(false)
                             .required(true))
+                        .arg(Arg::with_name("loop-count")
+                            .long("loop-count")
+                            .help("Number of loops the Animation is shown")
+                            .takes_value(true)
+                            .value_name("num"))
                         .get_matches_from(wild::args_os());
 
     let mut frames: Vec<_> = matches.values_of("FILE").ok_or("Missing files")?.collect();
@@ -123,6 +128,7 @@ fn bin_main() -> BinResult<()> {
         quality: parse_opt(matches.value_of("quality")).map_err(|_| "Invalid quality")?.unwrap_or(100),
         once: matches.is_present("once"),
         fast: matches.is_present("fast"),
+        loop_count: parse_opt(matches.value_of("loop-count")).map_err(|_| "Invalid loop-count")?.unwrap_or(0),
     };
     let quiet = matches.is_present("quiet");
     let fps: f32 = matches.value_of("fps").ok_or("Missing fps")?.parse().map_err(|_| "FPS must be a number")?;
@@ -150,6 +156,9 @@ fn bin_main() -> BinResult<()> {
         eprintln!("warning: web browsers support max 50 fps");
     }
 
+    if settings.loop_count > 0 {
+        settings.once = true;
+    }
     check_if_paths_exist(&frames)?;
 
     let mut decoder = if frames.len() == 1 {

--- a/src/bin/gifski.rs
+++ b/src/bin/gifski.rs
@@ -108,7 +108,7 @@ fn bin_main() -> BinResult<()> {
                             .required(true))
                         .arg(Arg::with_name("loop-count")
                             .long("loop-count")
-                            .help("Number of loops the Animation is shown")
+                            .help("Number of loops the animation is shown")
                             .takes_value(true)
                             .value_name("num"))
                         .get_matches_from(wild::args_os());
@@ -128,7 +128,7 @@ fn bin_main() -> BinResult<()> {
         quality: parse_opt(matches.value_of("quality")).map_err(|_| "Invalid quality")?.unwrap_or(100),
         once: matches.is_present("once"),
         fast: matches.is_present("fast"),
-        loop_count: parse_opt(matches.value_of("loop-count")).map_err(|_| "Invalid loop-count")?.unwrap_or(0),
+        loop_count: parse_opt(matches.value_of("loop-count")).map_err(|_| "Invalid loop count")?.unwrap_or(0),
     };
     let quiet = matches.is_present("quiet");
     let fps: f32 = matches.value_of("fps").ok_or("Missing fps")?.parse().map_err(|_| "FPS must be a number")?;
@@ -159,6 +159,7 @@ fn bin_main() -> BinResult<()> {
     if settings.loop_count > 0 {
         settings.once = true;
     }
+
     check_if_paths_exist(&frames)?;
 
     let mut decoder = if frames.len() == 1 {

--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -49,6 +49,8 @@ pub struct GifskiSettings {
     pub once: bool,
     /// Lower quality, but faster encode.
     pub fast: bool,
+    /// If once is true, times_shown is the number of times the animation is shown
+    pub loop_count: u16,
 }
 
 #[repr(C)]
@@ -89,6 +91,7 @@ pub unsafe extern "C" fn gifski_new(settings: *const GifskiSettings) -> *const G
         quality: settings.quality,
         once: settings.once,
         fast: settings.fast,
+        loop_count: settings.loop_count,
     };
 
     if let Ok((collector, writer)) = new(s) {
@@ -418,6 +421,7 @@ fn c_cb() {
             quality: 100,
             once: true,
             fast: false,
+            loop_count: 1,
         })
     };
     assert!(!g.is_null());
@@ -451,6 +455,7 @@ fn cant_write_after_finish() {
         quality: 100,
         once: true,
         fast: false,
+        loop_count: 1,
     })};
     assert!(!g.is_null());
     let mut called = false;
@@ -472,6 +477,7 @@ fn c_write_failure_propagated() {
         quality: 100,
         once: true,
         fast: false,
+        loop_count: 1,
     })};
     assert!(!g.is_null());
     unsafe extern fn cb(_s: usize, _buf: *const u8, _user: *mut c_void) -> c_int {
@@ -491,6 +497,7 @@ fn cant_write_twice() {
         quality: 100,
         once: true,
         fast: false,
+        loop_count: 1,
     })};
     assert!(!g.is_null());
     unsafe extern "C" fn cb(_s: usize, _buf: *const u8, _user: *mut c_void) -> c_int {
@@ -509,6 +516,7 @@ fn c_incomplete() {
         quality: 100,
         once: false,
         fast: true,
+        loop_count: 0,
     })};
 
     let rgb: *const RGB8 = ptr::null();

--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -49,7 +49,7 @@ pub struct GifskiSettings {
     pub once: bool,
     /// Lower quality, but faster encode.
     pub fast: bool,
-    /// If once is true, times_shown is the number of times the animation is shown
+    /// the loop count if once is false. 0 is forever.
     pub loop_count: u16,
 }
 

--- a/src/encodegifsicle.rs
+++ b/src/encodegifsicle.rs
@@ -76,12 +76,8 @@ impl Encoder for Gifsicle<'_> {
             };
             gfs.screen_width = screen_width;
             gfs.screen_height = screen_height;
-            if settings.once {
-                // -1 is no looping, 0 is loop forever, else loop X number of times
-                gfs.loopcount = if settings.loop_count == 0 { -1 } else { settings.loop_count.into() };
-            } else {
-                gfs.loopcount = 0; // forever
-            }
+            // -1 is no looping, 0 is loop forever, else loop X number of times
+            gfs.loopcount = if settings.once { -1 } else { settings.loop_count.into() };
             unsafe {
                 self.gif_writer = Gif_IncrementalWriteFileInit(gfs, &self.info, ptr::null_mut());
                 if self.gif_writer.is_null() {

--- a/src/encodegifsicle.rs
+++ b/src/encodegifsicle.rs
@@ -76,7 +76,12 @@ impl Encoder for Gifsicle<'_> {
             };
             gfs.screen_width = screen_width;
             gfs.screen_height = screen_height;
-            gfs.loopcount = if settings.once { 1 } else { 0 }; // 0 is correct, -1 is not
+            if settings.once {
+                // -1 is no looping, 0 is loop forever, else loop X number of times
+                gfs.loopcount = if settings.loop_count == 0 { -1 } else { settings.loop_count.into() };
+            } else {
+                gfs.loopcount = 0; // forever
+            }
             unsafe {
                 self.gif_writer = Gif_IncrementalWriteFileInit(gfs, &self.info, ptr::null_mut());
                 if self.gif_writer.is_null() {

--- a/src/encoderust.rs
+++ b/src/encoderust.rs
@@ -29,10 +29,12 @@ impl<W: Write> Encoder for RustEncoder<W> {
             None => {
                 let w = writer.take().expect("writer");
                 let mut enc = gif::Encoder::new(w, screen_width, screen_height, &[])?;
-                if settings.once {
-                    enc.write_extension(gif::ExtensionData::Repetitions(gif::Repeat::Finite(settings.loop_count)))?;
-                } else {
-                    enc.write_extension(gif::ExtensionData::Repetitions(gif::Repeat::Infinite))?;
+                if !settings.once {
+                    if settings.loop_count > 0 {
+                        enc.write_extension(gif::ExtensionData::Repetitions(gif::Repeat::Finite(settings.loop_count)))?;
+                    } else {
+                        enc.write_extension(gif::ExtensionData::Repetitions(gif::Repeat::Infinite))?;
+                    }
                 }
                 self.gif_enc.get_or_insert(enc)
             },

--- a/src/encoderust.rs
+++ b/src/encoderust.rs
@@ -29,7 +29,9 @@ impl<W: Write> Encoder for RustEncoder<W> {
             None => {
                 let w = writer.take().expect("writer");
                 let mut enc = gif::Encoder::new(w, screen_width, screen_height, &[])?;
-                if !settings.once {
+                if settings.once {
+                    enc.write_extension(gif::ExtensionData::Repetitions(gif::Repeat::Finite(settings.loop_count)))?;
+                } else {
                     enc.write_extension(gif::ExtensionData::Repetitions(gif::Repeat::Infinite))?;
                 }
                 self.gif_enc.get_or_insert(enc)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,8 @@ pub struct Settings {
     pub once: bool,
     /// Lower quality, but faster encode
     pub fast: bool,
+    /// If once is true, loop_count is the number of loops the animation is shown
+    pub loop_count: u16,
 }
 
 impl Settings {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,17 +46,17 @@ type DecodedImage = CatResult<(ImgVec<RGBA8>, f64)>;
 /// Encoding settings for the `new()` function
 #[derive(Copy, Clone, Default)]
 pub struct Settings {
-    /// Resize to max this width if set
+    /// Resize to max this width if set.
     pub width: Option<u32>,
     /// Resize to max this height if width is set. Note that aspect ratio is not preserved.
     pub height: Option<u32>,
     /// 1-100
     pub quality: u8,
-    /// If true, looping is disabled
+    /// If true, looping is disabled.
     pub once: bool,
-    /// Lower quality, but faster encode
+    /// Lower quality, but faster encode.
     pub fast: bool,
-    /// If once is true, loop_count is the number of loops the animation is shown
+    /// The loop count if once is false. 0 is forever.
     pub loop_count: u16,
 }
 


### PR DESCRIPTION
Prior to this change, gifski had 2 modes of looping animation, once and forever.

This change adds the ability to not loop, or set a fixed number of loops and keeps the ability to loop forever.