### PR TITLE
Adds option to disable duplicate frame skip

### DIFF
--- a/gifski.h
+++ b/gifski.h
@@ -53,6 +53,10 @@ typedef struct GifskiSettings {
    * Lower quality, but faster encode.
    */
   bool fast;
+  /**
+   * Don't skip identical frames.
+   */
+  bool no_duplicate_skip;
 } GifskiSettings;
 
 enum GifskiError {

--- a/src/bin/gifski.rs
+++ b/src/bin/gifski.rs
@@ -100,10 +100,9 @@ fn bin_main() -> BinResult<()> {
                             .long("quiet")
                             .short("q")
                             .help("Do not display anything on standard output/console"))
-                        .arg(Arg::with_name("no-skip-duplicates")
-                            .long("no-skip-duplicates")
-                            .short("N")
-                            .help("No skiping duplicate frames")
+                        .arg(Arg::with_name("no-duplicate-skip")
+                            .long("no-duplicate-skip")
+                            .help("Don't skip duplicate frames")
                             .empty_values(true))
                         .arg(Arg::with_name("FILE")
                             .help(VIDEO_FRAMES_ARG_HELP)
@@ -128,7 +127,7 @@ fn bin_main() -> BinResult<()> {
         quality: parse_opt(matches.value_of("quality")).map_err(|_| "Invalid quality")?.unwrap_or(100),
         once: matches.is_present("once"),
         fast: matches.is_present("fast"),
-        no_skip_duplicates: matches.is_present("no-skip-duplicates"),
+        no_duplicate_skip: matches.is_present("no-duplicate-skip"),
     };
     let quiet = matches.is_present("quiet");
     let fps: f32 = matches.value_of("fps").ok_or("Missing fps")?.parse().map_err(|_| "FPS must be a number")?;

--- a/src/bin/gifski.rs
+++ b/src/bin/gifski.rs
@@ -100,6 +100,11 @@ fn bin_main() -> BinResult<()> {
                             .long("quiet")
                             .short("q")
                             .help("Do not display anything on standard output/console"))
+                        .arg(Arg::with_name("no-skip-duplicates")
+                            .long("no-skip-duplicates")
+                            .short("N")
+                            .help("No skiping duplicate frames")
+                            .empty_values(true))
                         .arg(Arg::with_name("FILE")
                             .help(VIDEO_FRAMES_ARG_HELP)
                             .min_values(1)
@@ -123,6 +128,7 @@ fn bin_main() -> BinResult<()> {
         quality: parse_opt(matches.value_of("quality")).map_err(|_| "Invalid quality")?.unwrap_or(100),
         once: matches.is_present("once"),
         fast: matches.is_present("fast"),
+        no_skip_duplicates: matches.is_present("no-skip-duplicates"),
     };
     let quiet = matches.is_present("quiet");
     let fps: f32 = matches.value_of("fps").ok_or("Missing fps")?.parse().map_err(|_| "FPS must be a number")?;

--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -49,8 +49,8 @@ pub struct GifskiSettings {
     pub once: bool,
     /// Lower quality, but faster encode.
     pub fast: bool,
-    /// Skip identical frame
-    pub no_skip_duplicates: bool,
+    /// Don't skip identical frames.
+    pub no_duplicate_skip: bool,
 }
 
 #[repr(C)]
@@ -91,7 +91,7 @@ pub unsafe extern "C" fn gifski_new(settings: *const GifskiSettings) -> *const G
         quality: settings.quality,
         once: settings.once,
         fast: settings.fast,
-        no_skip_duplicates: settings.no_skip_duplicates,
+        no_duplicate_skip: settings.no_duplicate_skip,
     };
 
     if let Ok((collector, writer)) = new(s) {

--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -49,6 +49,8 @@ pub struct GifskiSettings {
     pub once: bool,
     /// Lower quality, but faster encode.
     pub fast: bool,
+    /// Skip identical frame
+    pub no_skip_duplicates: bool,
 }
 
 #[repr(C)]
@@ -89,6 +91,7 @@ pub unsafe extern "C" fn gifski_new(settings: *const GifskiSettings) -> *const G
         quality: settings.quality,
         once: settings.once,
         fast: settings.fast,
+        no_skip_duplicates: settings.no_skip_duplicates,
     };
 
     if let Ok((collector, writer)) = new(s) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,8 @@ pub struct Settings {
     pub once: bool,
     /// Lower quality, but faster encode
     pub fast: bool,
+    /// Skip identical frame
+    pub no_skip_duplicates: bool,
 }
 
 impl Settings {
@@ -372,7 +374,7 @@ impl Writer {
                 }
 
                 // Skip identical frames
-                if next.as_ref() == image.as_ref() {
+                if !_settings.no_skip_duplicates && next.as_ref() == image.as_ref() {
                     prev_frame_pts = pts;
                     continue;
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,8 +56,8 @@ pub struct Settings {
     pub once: bool,
     /// Lower quality, but faster encode
     pub fast: bool,
-    /// Skip identical frame
-    pub no_skip_duplicates: bool,
+    /// Don't skip identical frames
+    pub no_duplicate_skip: bool,
 }
 
 impl Settings {
@@ -374,7 +374,7 @@ impl Writer {
                 }
 
                 // Skip identical frames
-                if !_settings.no_skip_duplicates && next.as_ref() == image.as_ref() {
+                if !_settings.no_duplicate_skip && next.as_ref() == image.as_ref() {
                     prev_frame_pts = pts;
                     continue;
                 }


### PR DESCRIPTION
This option allows to disable frame duplication optimization. This way you can create identical animations based on source frames.
I noticed desyncs with the animations when duplicate frames where optimized. 