### PR TITLE
Make unnecessary dependencies optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,11 @@ edition = "2021"
 [[bin]]
 doctest = false
 name = "gifski"
+required-features = ["clap", "wild", "natord", "dunce"]
 
 [dependencies]
 gifsicle = { version = "1.92.5", optional = true }
-clap = { version = "3.0.14", features = ["cargo"] }
+clap = { version = "3.0.14", features = ["cargo"], optional = true }
 gif = "0.11.3"
 gif-dispose = "3.1.1"
 imagequant = "4.0.0"
@@ -29,10 +30,10 @@ lodepng = "3.5.2"
 pbr = "1.0.4"
 resize = "0.7.2"
 rgb = "0.8.31"
-wild = "2.0.4"
-natord = "1.0.9"
+wild = { version = "2.0.4", optional = true }
+natord = { version = "1.0.9", optional = true }
 quick-error = "2.0.1"
-dunce = "1.0.2"
+dunce = { version = "1.0.2", optional = true }
 crossbeam-channel = "0.5.2"
 
 [dependencies.ffmpeg]
@@ -43,7 +44,9 @@ default-features = false
 features = ["codec", "format", "filter", "software-resampling", "software-scaling"]
 
 [features]
-default = ["gifsicle"]
+# cargo build will skip the binaries with missing required-features
+# so all CLI dependencies have to be enabled by default
+default = ["gifsicle", "clap", "wild", "natord", "dunce"]
 openmp = [] # deprecated, obsolete
 openmp-static = [] # deprecated, obsolete
 video = ["ffmpeg"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,11 @@ edition = "2021"
 [[bin]]
 doctest = false
 name = "gifski"
-required-features = ["clap", "wild", "natord", "dunce"]
+required-features = ["clap", "png", "pbr", "wild", "natord", "dunce"]
+
+[[test]]
+name = "tests"
+required-features = ["png"]
 
 [dependencies]
 gifsicle = { version = "1.92.5", optional = true }
@@ -26,8 +30,8 @@ gif = "0.11.3"
 gif-dispose = "3.1.1"
 imagequant = "4.0.0"
 imgref = "1.9.1"
-lodepng = "3.5.2"
-pbr = "1.0.4"
+lodepng = { version = "3.5.2", optional = true }
+pbr = { version = "1.0.4", optional = true }
 resize = "0.7.2"
 rgb = "0.8.31"
 wild = { version = "2.0.4", optional = true }
@@ -46,7 +50,8 @@ features = ["codec", "format", "filter", "software-resampling", "software-scalin
 [features]
 # cargo build will skip the binaries with missing required-features
 # so all CLI dependencies have to be enabled by default
-default = ["gifsicle", "clap", "wild", "natord", "dunce"]
+default = ["gifsicle", "clap", "png", "pbr", "wild", "natord", "dunce"]
+png = ["lodepng"]
 openmp = [] # deprecated, obsolete
 openmp-static = [] # deprecated, obsolete
 video = ["ffmpeg"]

--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -143,6 +143,7 @@ pub unsafe extern "C" fn gifski_new(settings: *const GifskiSettings) -> *const G
 ///
 /// Returns 0 (`GIFSKI_OK`) on success, and non-0 `GIFSKI_*` constant on error.
 #[no_mangle]
+#[cfg(feature = "png")]
 pub unsafe extern "C" fn gifski_add_frame_png_file(handle: *const GifskiHandle, frame_number: u32, file_path: *const c_char, presentation_timestamp: f64) -> GifskiError {
     if file_path.is_null() {
         return GifskiError::NULL_ARG;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,6 @@ mod encodegifsicle;
 
 use crossbeam_channel::{Receiver, Sender};
 use std::io::prelude::*;
-use std::path::PathBuf;
 use std::thread;
 use std::borrow::Cow;
 
@@ -217,7 +216,8 @@ impl Collector {
     /// Presentation timestamp is time in seconds (since file start at 0) when this frame is to be displayed.
     ///
     /// If the first frame doesn't start at pts=0, the delay will be used for the last frame.
-    pub fn add_frame_png_file(&mut self, frame_index: usize, path: PathBuf, presentation_timestamp: f64) -> CatResult<()> {
+    #[cfg(feature = "png")]
+    pub fn add_frame_png_file(&mut self, frame_index: usize, path: std::path::PathBuf, presentation_timestamp: f64) -> CatResult<()> {
         let width = self.width;
         let height = self.height;
         let image = lodepng::decode32_file(&path)

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,5 +1,5 @@
+#[cfg(feature = "pbr")]
 pub use pbr::ProgressBar;
-use std::io::Stdout;
 use std::os::raw::{c_int, c_void};
 
 /// A trait that is used to report progress to some consumer.
@@ -44,7 +44,8 @@ impl ProgressReporter for ProgressCallback {
 
 /// Implement the progress reporter trait for a progress bar,
 /// to make it usable for frame processing reporting.
-impl ProgressReporter for ProgressBar<Stdout> {
+#[cfg(feature = "pbr")]
+impl<T> ProgressReporter for ProgressBar<T> where T: std::io::Write + Send {
     fn increase(&mut self) -> bool {
         self.inc();
         true


### PR DESCRIPTION
Currently, using gifski as a library will bring in 81 dependencies , including `clap`, `dunce`, `natord` and other irrelevant crates. Although unused symbols can be pruned at link time, they add clutter and greatly increase compile time (~45% in my case). This PR gives the option to exclude them with `default-features = false` while keeping backward compatibility.

The first commit makes all cli-only dependencies optional+default. Unfortunately cargo doesn't support something like `[bin-dependencies]` (rust-lang/cargo#1982), so the solution isn't as clean as I'd like.

The second commit makes `lodepng` and `pbr` optional+default. A lot of people probably don't need the very specific ability to load png (and only png) from local files (and only local files), and it's not a small crate by itself. And `pbr`, the progress bar crate, is self-explanatory. They're not as significant as `clap` and co though.

Here's the `cargo tree` comparison:

<details>
<summary>Expand</summary>

```diff
 gifski
-├── clap v3.0.14
-│   ├── atty v0.2.14
-│   │   └── winapi v0.3.9
-│   ├── bitflags v1.3.2
-│   ├── indexmap v1.8.0
-│   │   └── hashbrown v0.11.2
-│   │       └── ahash v0.7.6
-│   │           ├── getrandom v0.2.4
-│   │           │   └── cfg-if v1.0.0
-│   │           └── once_cell v1.9.0
-│   │           [build-dependencies]
-│   │           └── version_check v0.9.4
-│   │   [build-dependencies]
-│   │   └── autocfg v1.0.1
-│   ├── lazy_static v1.4.0
-│   ├── os_str_bytes v6.0.0
-│   │   └── memchr v2.4.1
-│   ├── strsim v0.10.0
-│   ├── termcolor v1.1.2
-│   │   └── winapi-util v0.1.5
-│   │       └── winapi v0.3.9
-│   └── textwrap v0.14.2
 ├── crossbeam-channel v0.5.2
 │   ├── cfg-if v1.0.0
 │   └── crossbeam-utils v0.8.6
 │       ├── cfg-if v1.0.0
 │       └── lazy_static v1.4.0
-├── dunce v1.0.2
 ├── gif v0.11.3
 │   ├── color_quant v1.1.0
 │   └── weezl v0.1.5
 ├── gif-dispose v3.1.1
 │   ├── gif v0.11.3 (*)
 │   ├── imgref v1.9.1
 │   └── rgb v0.8.31
 │       └── bytemuck v1.7.3
 ├── gifsicle v1.92.5
 │   └── libc v0.2.117
 │   [build-dependencies]
 │   └── cc v1.0.72
 ├── imagequant v4.0.0
 │   ├── arrayvec v0.7.2
 │   ├── fallible_collections v0.4.4
 │   │   └── hashbrown v0.11.2 (*)
 │   ├── noisy_float v0.2.0
 │   │   └── num-traits v0.2.14
 │   │       [build-dependencies]
 │   │       └── autocfg v1.0.1
 │   ├── once_cell v1.9.0
 │   ├── rayon v1.5.1
 │   │   ├── crossbeam-deque v0.8.1
 │   │   │   ├── cfg-if v1.0.0
 │   │   │   ├── crossbeam-epoch v0.9.6
 │   │   │   │   ├── cfg-if v1.0.0
 │   │   │   │   ├── crossbeam-utils v0.8.6 (*)
 │   │   │   │   ├── lazy_static v1.4.0
 │   │   │   │   ├── memoffset v0.6.5
 │   │   │   │   │   [build-dependencies]
 │   │   │   │   │   └── autocfg v1.0.1
 │   │   │   │   └── scopeguard v1.1.0
 │   │   │   └── crossbeam-utils v0.8.6 (*)
 │   │   ├── either v1.6.1
 │   │   └── rayon-core v1.9.1
 │   │       ├── crossbeam-channel v0.5.2 (*)
 │   │       ├── crossbeam-deque v0.8.1 (*)
 │   │       ├── crossbeam-utils v0.8.6 (*)
 │   │       ├── lazy_static v1.4.0
 │   │       └── num_cpus v1.13.1
 │   │   [build-dependencies]
 │   │   └── autocfg v1.0.1
 │   ├── rgb v0.8.31 (*)
 │   └── thread_local v1.1.4
 │       └── once_cell v1.9.0
 ├── imgref v1.9.1
-├── lodepng v3.5.2
-│   ├── crc32fast v1.3.1
-│   │   └── cfg-if v1.0.0
-│   ├── fallible_collections v0.4.4 (*)
-│   ├── flate2 v1.0.22
-│   │   ├── cfg-if v1.0.0
-│   │   ├── crc32fast v1.3.1 (*)
-│   │   ├── libc v0.2.117
-│   │   └── miniz_oxide v0.4.4
-│   │       └── adler v1.0.2
-│   │       [build-dependencies]
-│   │       └── autocfg v1.0.1
-│   ├── libc v0.2.117
-│   └── rgb v0.8.31 (*)
-├── natord v1.0.9
-├── pbr v1.0.4
-│   ├── crossbeam-channel v0.5.2 (*)
-│   ├── libc v0.2.117
-│   ├── time v0.1.43
-│   │   ├── libc v0.2.117
-│   │   └── winapi v0.3.9
-│   └── winapi v0.3.9
 ├── quick-error v2.0.1
 ├── resize v0.7.2
 │   ├── fallible_collections v0.4.4 (*)
 │   └── rgb v0.8.31 (*)
 ├── rgb v0.8.31 (*)
-└── wild v2.0.4
-    └── glob v0.3.0
```

</details>
