### PR TITLE
Remove unnecessary mut from add_frame closure

### DIFF
--- a/src/bin/ffmpeg_source.rs
+++ b/src/bin/ffmpeg_source.rs
@@ -70,7 +70,7 @@ impl FfmpegDecoder {
         };
 
 
-        let mut add_frame = |rgba_frame: &ffmpeg::util::frame::Video, pts: f64, pos: i64| -> BinResult<()> {
+        let add_frame = |rgba_frame: &ffmpeg::util::frame::Video, pts: f64, pos: i64| -> BinResult<()> {
             let stride = rgba_frame.stride(0) as usize;
             if stride % 4 != 0 {
                 Err("incompatible video")?;


### PR DESCRIPTION
This PR fixes the following compiler warning during `cargo build`:

```
warning: variable does not need to be mutable
  --> src/bin/ffmpeg_source.rs:73:13
   |
73 |         let mut add_frame = |rgba_frame: &ffmpeg::util::frame::Video, pts: f64, pos: i64| -> BinResult<()> {
   |             ----^^^^^^^^^
   |             |
   |             help: remove this `mut`
   |
   = note: `#[warn(unused_mut)]` on by default
```
