### PR TITLE
Support ffmpeg 5.x and 6.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ scopeguard = "1.1.0"
 
 [dependencies.ffmpeg]
 package = "ffmpeg-next"
-version = "4.4.0"
+version = ">= 4.4.0, < 7"
 optional = true
 default-features = false
 features = ["codec", "format", "filter", "software-resampling", "software-scaling"]


### PR DESCRIPTION
Adds support for ffmpeg 5.x and 6.x (fixes #242).

The code has been tested with both ffmpeg 4.4 and 6.0 on Arch Linux. It should work with 5.0 too since the same APIs are available but I haven't tested that.

The [forked `ffmpeg-sys-next`](../blob/1.10.3/Cargo.toml#L91) with cross-compilation fixes has version 4.4.0 of `ffmpeg-sys-next`, so it can't be used until the fork is updated to a newer version. Cargo will emit a warning and ignore the fork when building with newer ffmpeg.