### PR TITLE
Add support for building a shared library with cargo-c

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ features = ["codec", "format", "filter", "software-resampling", "software-scalin
 # so all CLI dependencies have to be enabled by default
 default = ["gifsicle", "binary"]
 binary = ["dep:clap", "png", "pbr", "dep:wild", "dep:natord", "dep:dunce"]
+capi = [] # internal for cargo-c only
 png = ["dep:lodepng"]
 openmp = [] # deprecated, obsolete
 openmp-static = [] # deprecated, obsolete
@@ -86,6 +87,13 @@ strip = true
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[package.metadata.capi.header]
+subdirectory = false
+generation = false
+
+[package.metadata.capi.install.include]
+asset = [{from = "gifski.h"}]
 
 [patch.crates-io]
 # ffmpeg-sys-next does not support cross-compilation, which I use to produce binaries https://github.com/zmwangx/rust-ffmpeg-sys/pull/30

--- a/README.md
+++ b/README.md
@@ -55,6 +55,21 @@ cargo build --release
 
 and link with `target/release/libgifski.a`. Please observe the [LICENSE](LICENSE).
 
+### C dynamic library for package maintainers
+
+The build process uses [`cargo-c`](https://lib.rs/cargo-c) for building the dynamic library correctly and generating the pkg-config file.
+
+```sh
+rustup update
+cargo install cargo-c
+# build
+cargo cbuild --prefix=/usr --release
+# install
+cargo cinstall --prefix=/usr --release --destdir=pkgroot
+```
+
+The `cbuild` command can be omitted, since `cinstall` will trigger a build if it hasn't been done already.
+
 ## License
 
 AGPL 3 or later. I can offer alternative licensing options, including [commercial licenses](https://supso.org/projects/pngquant). Let [me](https://kornel.ski/contact) know if you'd like to use it in a product incompatible with this license.


### PR DESCRIPTION
Adds option to build a shared library using [cargo-c](https://lib.rs/cargo-c).

The existing `gifski.h` header file is used. If you think that it would be better to generate it with cbindgen I can implement that too.