### PR TITLE
Fix null reference in c_api.rs test

### DIFF
--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -758,9 +758,7 @@ fn c_incomplete() {
         fast: true,
         repeat: 0,
     })};
-
-    let rgb: *const RGB8 = ptr::null();
-    assert_eq!(3, mem::size_of_val(unsafe { &*rgb }));
+    assert_eq!(3, mem::size_of::<RGB8>());
 
     assert!(!g.is_null());
     unsafe {


### PR DESCRIPTION
I am working on a compiler patch that automatically inserts checks for null pointers and null-backed references in debug mode (https://github.com/rust-lang/rust/pull/134424). As part of my change I noticed that it breaks gifski's c_api.rs tests. This patch fixes the issue so that you will not be broken by a new toolchain release.

I also want to point out that it maybe makes sense to let at least the c_api part run under Miri, to catch potentially more unsoundness, I wonder if that has already happened, if not I am happy to lend a hand to set-up a Github actions workflow or similar.