### PR TITLE
Add CI to build on WebAssembly

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,22 @@
+name: Wasm
+
+on:
+  push:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Prepare cargo tests
+      run: rustup target add wasm32-unknown-emscripten
+
+    - name: Build for wasm
+      run: cargo build --target=wasm32-unknown-emscripten
+


### PR DESCRIPTION
I am trying to build this package for emscripten. Currently it fails with:

```
no variant or associated item named `Path` found for enum `FrameSource` in the current scope
```

Perhaps there is a way to support emscripten VFS?

This PR adds the CI to reproduce the error.