### PR TITLE
bump indirect syn dep to 2.0.117

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -382,6 +382,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -641,20 +651,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.110"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.114"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -720,7 +719,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
  "wasm-bindgen-shared",
 ]
 


### PR DESCRIPTION
Fixes a build error:
```
	error: failed to select a version for `syn`.
	    ... required by package `wasm-bindgen-macro-support v0.2.108`
	    ... which satisfies dependency `wasm-bindgen-macro-support = "=0.2.108"` (locked to 0.2.108) of package `wasm-bindgen-macro v0.2.108`
	    ... which satisfies dependency `wasm-bindgen-macro = "=0.2.108"` (locked to 0.2.108) of package `wasm-bindgen v0.2.108`
	    ... which satisfies dependency `wasm-bindgen = "^0.2.108"` (locked to 0.2.108) of package `gifski v1.34.0 (/home/aissen/dev/slackanim/gifski)`
	versions that meet the requirements `^2.0` (locked to 2.0.114) are: 2.0.114

	all possible versions conflict with previously selected packages.

	  previously selected package `syn v2.0.110`
	    ... which satisfies dependency `syn = "^2.0"` (locked to 2.0.110) of package `bindgen v0.72.1`
	    ... which satisfies dependency `bindgen = "^0.72"` (locked to 0.72.1) of package `ffmpeg-sys-next v8.0.1`
	    ... which satisfies dependency `ffmpeg-sys-next = "^8.0.0"` (locked to 8.0.1) of package `ffmpeg-next v8.0.0`
	    ... which satisfies dependency `ffmpeg = "^8"` (locked to 8.0.0) of package `gifski v1.34.0 (/home/aissen/dev/slackanim/gifski)`

	failed to select a version for `syn` which could resolve this conflict
```