### PR TITLE
Fix wasm build

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Setup emscripten
+      uses: mymindstorm/setup-emsdk@v14
+
     - name: Prepare cargo tests
       run: |
         rustup target add wasm32-unknown-emscripten --toolchain=nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,10 @@ yuv = { version = "0.1.9", optional = true }
 wasm-bindgen = { version = "0.2.108", optional = true }
 web-sys = {version="0.3.85", features = ["console"], optional = true }
 console_error_panic_hook = {version = "0.1.7", optional = true}
+
+# Only for browser wasm (wasm-pack). Requires RUSTFLAGS with +atomics,+bulk-memory.
+# Not used on wasm32-unknown-emscripten, where rayon uses pthreads instead.
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 wasm-bindgen-rayon = "1.3.0"
 
 [dependencies.ffmpeg]

--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -221,7 +221,7 @@ pub unsafe extern "C" fn gifski_add_fixed_color(handle: *mut GifskiHandle, col_r
 ///
 /// Returns 0 (`GIFSKI_OK`) on success, and non-0 `GIFSKI_*` constant on error.
 #[no_mangle]
-#[cfg(feature = "png")]
+#[cfg(all(feature = "png", not(all(target_arch = "wasm32", target_os = "unknown"))))]
 pub unsafe extern "C" fn gifski_add_frame_png_file(handle: *const GifskiHandle, frame_number: u32, file_path: *const c_char, presentation_timestamp: f64) -> GifskiError {
     if file_path.is_null() {
         return GifskiError::NULL_ARG;

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -9,14 +9,14 @@ pub use rgb::{RGB8, RGBA8};
 use crate::error::GifResult;
 use crossbeam_channel::Sender;
 
-#[cfg(feature = "png")]
+#[cfg(all(feature = "png", not(all(target_arch = "wasm32", target_os = "unknown"))))]
 use std::path::PathBuf;
 
 pub(crate) enum FrameSource {
     Pixels(ImgVec<RGBA8>),
     #[cfg(feature = "png")]
     PngData(Vec<u8>),
-    #[cfg(all(feature = "png", not(target_arch = "wasm32")))]
+    #[cfg(all(feature = "png", not(all(target_arch = "wasm32", target_os = "unknown"))))]
     Path(PathBuf),
 }
 
@@ -102,7 +102,7 @@ impl Collector {
     /// If the first frame doesn't start at pts=0, the delay will be used for the last frame.
     ///
     /// If this function appears to be stuck after a few frames, it's because [`crate::Writer::write()`] is not running.
-    #[cfg(feature = "png")]
+    #[cfg(all(feature = "png", not(all(target_arch = "wasm32", target_os = "unknown"))))]
     pub fn add_frame_png_file(&self, frame_index: usize, path: PathBuf, presentation_timestamp: f64) -> GifResult<()> {
         self.queue.send(InputFrame {
             frame: FrameSource::Path(path),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -631,7 +631,7 @@ impl Writer {
                             .map_err(|err| Error::PNG(format!("Can't load PNG: {err}")))?;
                         Img::new(image.buffer, image.width, image.height)
                     },
-                    #[cfg(feature = "png")]
+                    #[cfg(all(feature = "png", not(all(target_arch = "wasm32", target_os = "unknown"))))]
                     FrameSource::Path(path) => {
                         let image = lodepng::decode32_file(&path)
                             .map_err(|err| Error::PNG(format!("Can't load {}: {err}", path.display())))?;

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -95,7 +95,8 @@ impl GifskiWasm {
     }
 }
 
-// thread pool for wasm-bindgen-rayon
+// thread pool for wasm-bindgen-rayon (browser wasm only; emscripten uses pthreads)
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 #[wasm_bindgen]
 pub fn init_thread_pool(num_threads: usize) -> Result<(), JsValue> {
     wasm_bindgen_rayon::init_thread_pool(num_threads);


### PR DESCRIPTION
Your CI doesn't run on pull requests but I tested it in my fork here: https://github.com/jeroen/cargo-gifski/actions/runs/27310811831/job/80680244284

The `FrameSource::Path` variant was gated on `not(wasm32)` but its use sites weren't. Narrowed the gate to `not(wasm32-unknown-unknown)`, since emscripten has a filesystem and I need `add_frame_png_file` in my R bindings.
